### PR TITLE
Pin Underscore + Backbone versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "gitHead": "7154c5e376ad257a0601152b104609f784abcc03",
   "dependencies": {
     "mocha": "*",
-    "underscore": "~1.5.1",
-    "backbone": "~1.0.0",
+    "underscore": "1.8.3",
+    "backbone": "1.2.3",
     "sinon": "~1.7.3",
     "backbone-virtual-collection": "~0.6.0"
   }


### PR DESCRIPTION
to the same versions required by other parts of the Ironboard ecosystem so that we aren't bundling multiple versions of each library (2 Backbones and 3 Underscores) in our commons chunk.